### PR TITLE
Fix for when used as dependency through npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "signal-arr",
   "version": "0.0.14",
   "description": "A piratey version of the SignalR Javascript client without stupid jquery.",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
     "dev": "./node_modules/.bin/babel src -s -w -d dist",
     "clean": "./node_modules/.bin/rimraf dist coverage",
-    "build": "./node_modules/.bin/babel src -s -o index.js",
+    "build": "./node_modules/.bin/babel src -s -d dist",
     "test": "./node_modules/.bin/mocha",
-    "test-cov": "./node_modules/.bin/babel-istanbul cover node_modules/.bin/_mocha -- test && cat ./coverage/lcov.info | node_modules/coveralls/bin/coveralls.js && rimraf ./coverage",
+    "test-cov": "./node_modules/.bin/babel-istanbul over node_modules/.bin/_mocha -- test && cat ./coverage/lcov.info | node_modules/coveralls/bin/coveralls.js && rimraf ./coverage",
     "lint": "./node_modules/.bin/eslint src"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "./node_modules/.bin/babel src -s -d dist",
     "test": "./node_modules/.bin/mocha",
     "test-cov": "./node_modules/.bin/babel-istanbul over node_modules/.bin/_mocha -- test && cat ./coverage/lcov.info | node_modules/coveralls/bin/coveralls.js && rimraf ./coverage",
-    "lint": "./node_modules/.bin/eslint src"
+    "lint": "./node_modules/.bin/eslint src",
+    "prepublish": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
As part of the build process all the source files would be bundled into a single file. However, all this does is concatenate the files after compilation.  This causes the `exports` definitions to clash and the intermodule `require` calls to not work. 

Instead, this change builds each separate module and places them inside the `dist` folder, not unlike the `dev` script. With the `main` property of the `package.json` also pointing there the module can now be required without errors. 

```
const signalArr = require('signal-arr')
```

Bonus: publishing each module individually allows to only include a single module.

```
const hubClient = require('signal-arr/dist/HubClient')

// or

const ConnectingMessageBuffer = require('signal-arr/dist/ConnectingMessageBuffer')
```

For convenience I also added a `prepublish` script to the `package.json`, making sure the build is always run just before publishing to npm.
